### PR TITLE
Better selection colors

### DIFF
--- a/src/one-nord.yml
+++ b/src/one-nord.yml
@@ -63,12 +63,13 @@ one-nord:
     - &COLOR14       '#8FBCBB'
     - &COLOR15       '#ECEFF4'
   other:
-    - &LineHighlight !alpha [ *BLUE, "99" ]
+    - &LineHighlight !alpha [ *BLUE, "80" ]
     - &NonText       !alpha [ *HL4, "B3" ]
     - &WHITE         !alpha [ *BLUE, "33" ]
     - &TAB_DROP_BG   !alpha [ *COMMENT, "99" ]
     # UI Variants
     - &BGLighter     !alpha [ *HL3, "99" ]
+    - &BGDarker     !alpha [ *HL3, "80" ]
     - &BGLight       '#2E3440'
     - &BGDark        '#3B4252'
     - &SHADOW        '#00000066'
@@ -223,7 +224,7 @@ colors:
 
   editor.selectionBackground: *BGLighter                                       # Color of the editor selection
   editor.selectionHighlightBackground: *BGLighter                              # Color for regions with the same content as the selection
-  editor.inactiveSelectionBackground: *BGLighter                               # Color of the selection in an inactive editor
+  editor.inactiveSelectionBackground: *BGDarker                                # Color of the selection in an inactive editor
   editor.foldBackground: *BGLighter                                            # Background color for folded ranges
 
   editor.wordHighlightBackground: !alpha [ *BLUE, "66" ]                       # Background color of a symbol during read-access, for example when reading a variable


### PR DESCRIPTION
Fixes https://github.com/s1e2b3i4/onenord-vscode/issues/10

Reduce opacity by 10% for `selection.background` so it's not too bright.

### Before (`selection.background`)

<img width="443" alt="selection background - before" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/18f8bd61-6e16-48ac-a305-d762a14760b0">

### After (`selection.background`)

<img width="458" alt="selection background - after" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/e6444099-0981-48cc-b9fb-f5ad0f802b6e">

<hr/>

Fix SCM view and other inputs selection color. Also, in order to fix it I had to modify existing editor selection color, but it's actually better since it's more brighter. And, additionally I made a diff between focused and unfocused editor with selection.

### Before (input selection)

<img width="281" alt="input selection - before" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/52bb2637-cf0b-4f8b-971d-233507e51c0e">

### After (input selection)

<img width="290" alt="input selection - after" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/caeddfd9-93ed-4698-a318-66146b54e698">

### Before (editor selection)

<img width="1618" alt="editor selection - before" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/071c4c40-80cc-4355-8834-783e3f8fcc31">

### After (editor selection)

<img width="1625" alt="editor selection - after" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/e086004f-7d18-4f77-9d6e-dded430c27b5">