### PR TITLE
Better contrast for marker navigation background

### DIFF
--- a/src/one-nord.yml
+++ b/src/one-nord.yml
@@ -330,7 +330,7 @@ colors:
   editorHoverWidget.background: *COMMENT                                       # Background color of the editor hover
   editorHoverWidget.border: *COMMENT                                           # Border color of the editor hover
 
-  editorMarkerNavigation.background: !alpha [ *BLUE_DARK, "C0" ]               # Editor marker navigation widget background
+  editorMarkerNavigation.background: *BGDark                                   # Editor marker navigation widget background
   editorMarkerNavigationError.background: !alpha [ *RED_DARK, "C0" ]           # Editor marker navigation widget error color
   editorMarkerNavigationWarning.background: !alpha [ *ORANGE, "C0" ]           # Editor marker navigation widget warning color
 


### PR DESCRIPTION
Fixes https://github.com/s1e2b3i4/onenord-vscode/issues/8

### Before

<img width="824" alt="marker-navigation-before" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/b42a9870-74eb-44f7-b321-4d397637812d">

### After

<img width="828" alt="marker-navigation-after" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/3703ce71-4c02-4487-8d93-1b8771c921ea">
