### PR TITLE
Better peek view result colors

### DIFF
--- a/src/one-nord.yml
+++ b/src/one-nord.yml
@@ -341,8 +341,8 @@ colors:
   peekViewEditor.matchHighlightBackground: !alpha [ *BLUE, "4D" ]              # Match highlight color in the peek view editor
   peekViewResult.background: *BGLight                                          # Background color of the peek view result list
   peekViewResult.fileForeground: *BLUE                                         # Foreground color for file nodes in the peek view result list
-  peekViewResult.lineForeground: !alpha [ *FG, "66" ]                                            # Foreground color for line nodes in the peek view result list
-  peekViewResult.matchHighlightBackground: !alpha [ *BLUE, "CC" ]              # Match highlight color in the peek view result list
+  peekViewResult.lineForeground: !alpha [ *FG, "b3" ]                          # Foreground color for line nodes in the peek view result list
+  peekViewResult.matchHighlightBackground: !alpha [ *BLUE, "80" ]              # Match highlight color in the peek view result list
   peekViewResult.selectionBackground: *HL3                                     # Background color of the selected entry in the peek view result list
   peekViewResult.selectionForeground: *FG                                      # Foreground color of the selected entry in the peek view result list
   peekViewTitle.background: *COMMENT                                           # Background color of the peek view title area


### PR DESCRIPTION
### Before

<img width="321" alt="peek-view-result-before" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/18b29846-8c5c-49ad-9181-2f86be5ff1f5">

### After

<img width="300" alt="peek-view-result-after" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/a9514c4b-b58e-40e5-a4df-579b2846ab68">
