### PR TITLE
Fix some semantic colors

### DIFF
--- a/src/one-nord.yml
+++ b/src/one-nord.yml
@@ -1302,7 +1302,7 @@ semanticTokenColors:
   variable:html: *RED
   variable.local:html: *BLUE_LIGHT
   property:html: *RED
-  property:python: *FG
+  property:python: *BLUE_LIGHT
   property.definition: *BLUE
   enumMember: *RED
   function: *BLUE


### PR DESCRIPTION
~Replace : with ., because : isn't valid and to access field you need to use .~ <- I reverted this one, I read documentation and seems `:` is used for language selection. **So what I did is only aligned python property color to match other semantic colors.**