### PR TITLE
Add semantic default library colors

### DIFF
--- a/src/one-nord.yml
+++ b/src/one-nord.yml
@@ -1292,6 +1292,7 @@ semanticTokenColors:
   type: *YELLOW
   class.declaration: *YELLOW
   class.builtin: *CYAN
+  class.defaultLibrary: *GREEN_LIGHT
   interface: *YELLOW
   enum: *YELLOW
   typeParameter: *YELLOW
@@ -1300,10 +1301,12 @@ semanticTokenColors:
   selfParameter: *PURPLE
   variable: *BLUE_LIGHT
   variable:html: *RED
+  variable.defaultLibrary: *GREEN_LIGHT
   variable.local:html: *BLUE_LIGHT
   property:html: *RED
   property:python: *FG
   property.definition: *BLUE
+  property.defaultLibrary: *GREEN_LIGHT
   enumMember: *RED
   function: *BLUE
   function.builtin: *CYAN


### PR DESCRIPTION
### Before

<img width="386" alt="default-library-before" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/51f36c5c-ced7-40d4-bbff-3f0f36486090">

### After

<img width="246" alt="default-library-after" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/5ab4da62-a3a7-4a61-9fc6-0cd4eacadfa3">