### PR TITLE
Separate types vs class in semantic colors

### DIFF
--- a/themes/OneNord-color-theme.json
+++ b/themes/OneNord-color-theme.json
@@ -1519,15 +1519,15 @@
       }
     ],
     "semanticTokenColors": {
-      "namespace": "#EBCB8B",
+      "namespace": "#8FBCBB",
       "namespace:dockerfile": {
         "foreground": "#88C0D0",
         "fontStyle": "italic"
       },
-      "type": "#EBCB8B",
-      "class.declaration": "#EBCB8B",
+      "type": "#8FBCBB",
+      "class": "#EBCB8B",
       "class.builtin": "#88C0D0",
-      "interface": "#EBCB8B",
+      "interface": "#8FBCBB",
       "enum": "#EBCB8B",
       "typeParameter": "#EBCB8B",
       "parameter": "#D08F70",


### PR DESCRIPTION
Now it's very clear where interface/type vs class is used.

### Before (types from React)

<img width="734" alt="interface-class-before-1" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/814f1bd2-31d4-4715-8ee5-9e4188ded141">

### After (types from React)

<img width="750" alt="interface-class-after-1" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/b2e9200c-a691-43f8-833d-f5fc0c41728b">

### Before (some custom code)

<img width="354" alt="interface-class-before-2" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/e636bfa3-1a77-4148-a3a6-58404af1955f">

### After (some custom code)

<img width="334" alt="interface-class-after-2" src="https://github.com/s1e2b3i4/onenord-vscode/assets/10441177/e62f7132-6996-4636-92ca-f7b4d4637e27">
