### PR TITLE
ci: add GitHub actions for automatic publishing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,32 @@
+name: Create Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm install && mkdir -p ./bin
+      - run: npm run package
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bin/one-nord.vsix
+          asset_name: one-nord.vsix
+          asset_content_type: application/octet-stream

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy Release
+on:
+  release:
+    types:
+      - published
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm install
+      - env:
+          VSCE_PUBLISHER_TOKEN: ${{ secrets.VSCE_PUBLISHER_TOKEN }}
+        run: npm run vsce-publish -- -p $VSCE_PUBLISHER_TOKEN


### PR DESCRIPTION
# Description
In this PR I have added two Github actions that will help us automate some of our workflow.

# Changes in details
Let me explain in details how they work:
1. **release-please**: requires commits names to be written according to the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/) (es: `feat: add more Ruby specific colors`, `fix: adjust Python colortheme`...). 
Every time a commit (with a conventional name) that changes `src/one-nord.yml` is merged on `main`, a PR will be opened by `release-please`. This PR, when merged will: 
    - update the `CHANGELOG.md` automatically
    -  push a git tag automatically
    -  release the code to Github automatically with a Github release. 

2. **build-and-push**: when a new release is created on Github (by `release-please`), this action will checkout the repo, setup `node`, install dependencies via `npm` and will publish the theme to the Visual Studio Code Marketplace. @s1e2b3i4 in order for this to work, you need to add your own personal token in the `VSCE_TOKEN` repository secret.

# Motivation and context
With those 2 actions, the workflow for a new feature would be the following:
Somebody wants to add a color somewhere in the theme => he creates a PR with it's changes, where commits are in the form of `feat: ...` => we merge it's PR => `release-please` opens a PR for the new release => we merge this other PR => done! A new release is available on Github, the `CHANGELOG.md` file is up-to-date, and the extension is published to the marketplace automatically!

# Conclusion
WDYT about this? I think this will help @s1e2b3i4 a lot since he won't need to do much things manually!